### PR TITLE
Improve link to Google I/O announcement

### DIFF
--- a/web/_posts/2019-05-09-google-fonts-display.md
+++ b/web/_posts/2019-05-09-google-fonts-display.md
@@ -89,7 +89,7 @@ Want a [full history of FOIT and FOUT](/web/fout-foit-history/)?
 
 ## Related
 
-* [Video of the announcement at Google I/O](https://www.youtube.com/watch?time_continue=28095&v=cb_oxa4Y1Bc) (Starts at 7:48:15, is only about a minute long)
+* [Video of the announcement at Google I/O](https://www.youtube.com/watch?v=YJGCZCaIZkQ&t=31m20s)
 
 ## Future wishlist
 


### PR DESCRIPTION
There’s now a dedicated URL for Katie and Addy’s session.