### PR TITLE
fix broken url

### DIFF
--- a/web/_posts/2016-07-12-comprehensive-fontloading.md
+++ b/web/_posts/2016-07-12-comprehensive-fontloading.md
@@ -221,7 +221,7 @@ Use the CSS Font Loading API with a polyfill to detect when a specific font has 
 
 ### Pros
 
-* Rendering performance: Eliminates FOIT. This method is tried and tested. It’s [one of the approaches recommended by TypeKit](https://helpx.adobe.com/typekit/using/embed-codes.html#Advancedembedcode).
+* Rendering performance: Eliminates FOIT. This method is tried and tested. It’s [one of the approaches recommended by TypeKit](https://helpx.adobe.com/fonts/user-guide.html/fonts/using/embed-codes.ug.html#JavaScriptembedcode).
 * Flexibility: Easy to group requests into a single repaint (use one class for multiple web font loads)
 * Scalability: Requests happen in parallel
 * Robust: if the request fails, fallback text is still shown.


### PR DESCRIPTION
Redirect URL Content similar to archive:  https://web.archive.org/web/20180110214644/https://helpx.adobe.com/typekit/using/embed-codes.html#Advancedembedcode

Sorry for the tiny pull request - promise this isn't a hacktober thing.  Just enjoying the article and fixing dead links.  merge if you'd like.  K, Thanks :)