### PR TITLE
Fix incorrect alt for screenshot `<img>`

### DIFF
--- a/_11ty/imagePlugin.js
+++ b/_11ty/imagePlugin.js
@@ -163,8 +163,8 @@ function getScreenshotUrlFromPath(path, options) {
 	return getScreenshotUrl(u.toString(), options);
 }
 
-function screenshotImageHtmlFullUrl(fullUrl) {
-	let targetUrl = getScreenshotUrl(fullUrl);
+function screenshotImageHtmlFullUrl(targetUrl) {
+	let fullUrl = getScreenshotUrl(targetUrl);
 	let options = {
 		// format here is static
 		formats: ["jpeg"],
@@ -175,7 +175,7 @@ function screenshotImageHtmlFullUrl(fullUrl) {
 		}
 	};
 
-	let stats = Image.statsByDimensionsSync(targetUrl, 1200, 630, options);
+	let stats = Image.statsByDimensionsSync(fullUrl, 1200, 630, options);
 	return Image.generateHTML(stats, {
 		alt: `Screenshot image for ${targetUrl}`,
 		loading: "lazy",


### PR DESCRIPTION
**Problem**:

The alt text is set to "Screenshot for v1.screenshot.11ty.dev", followed by a percent-encoded version of the URL, instead of simply "Screenshot for github.com/example/foo".

https://www.zachleat.com/web/eleventy-three-beta/
![capture](https://github.com/user-attachments/assets/54942822-e8ee-4fd6-b988-361b755cbcb9)

**Solution**:
I've not tested or confirmed this, but this might be coming from `_11ty/imagePlugin.js` where there seems to be a mixup between the "targetUrl" and "fullUrl" variable names, which carry the opposite meaning than they do elsewhere in the same file. The opengraph version and its alt text was set correctly already.
